### PR TITLE
Add .env config and axios API module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5000

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,46 @@
+import axios from 'axios'
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
+})
+
+// Adjunta token en cada solicitud si existe
+api.interceptors.request.use(config => {
+  const token = localStorage.getItem('jwtToken')
+  if (token) {
+    config.headers = config.headers || {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export interface LoginPayload {
+  email: string
+  password: string
+}
+
+export const login = async (payload: LoginPayload) => {
+  const { data } = await api.post('/auth/login', payload)
+  return data
+}
+
+export interface SignupPayload {
+  email: string
+  password: string
+  rol: number
+  dni: string
+  nombre: string
+  apellidos: string
+  celular: string
+  sexo: 'M' | 'F'
+}
+
+export const register = async (payload: SignupPayload) => {
+  const { data } = await api.post('/auth/signup', payload)
+  return data
+}
+
+export const getCurrentUser = async () => {
+  const { data } = await api.get('/auth/me')
+  return data
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getCurrentUser } from '../api';
 
 const Header: React.FC = () => {
   const [nombre, setNombre] = useState<string>('');
@@ -8,20 +9,13 @@ const Header: React.FC = () => {
 
   useEffect(() => {
     const fetchUser = async () => {
-      const token = localStorage.getItem('jwtToken');
-      if (!token) return;
       try {
-        const res = await fetch('http://localhost:8081/auth/me', {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (res.ok) {
-          const data = await res.json();
-          setNombre(data.persona.nombre|| 'Usuario');
-        }
+        const data = await getCurrentUser()
+        setNombre(data.persona.nombre || 'Usuario')
       } catch (error) {
-        setNombre('Usuario');
+        setNombre('Usuario')
       }
-    };
+    }
     fetchUser();
   }, []);
 

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import type { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getCurrentUser } from '../services/auth';
+import { getCurrentUser, login } from '../api';
 interface LoginData {
     email: string;
     password: string;
@@ -31,31 +31,7 @@ const LoginForm: React.FC = () => {
         setLoading(true);
 
         try {
-            const resp = await fetch('http://localhost:8081/auth/login', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(formData),
-            });
-
-            if (!resp.ok) {
-                let errorMessage = 'Correo o contraseña incorrectos';
-                try {
-                    const errorData = await resp.json();
-                    errorMessage = errorData.message || errorMessage;
-                } catch {
-                    // Si no es JSON, intenta obtener el texto
-                    try {
-                        errorMessage = await resp.text() || errorMessage;
-                    } catch {
-                        // Ignorar si tampoco se puede obtener el texto
-                    }
-                }
-                throw new Error(errorMessage);
-            }
-
-            // Asumimos que la respuesta es { token: string, ... }
-            const data = await resp.json();
-
+            const data = await login(formData);
             const token: string = data.token;
             if (!token) throw new Error('No se recibió token del servidor');
 

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { listNodos } from '../services/nodos'
+import { listEstaciones } from '../services/estaciones'
 import 'leaflet/dist/leaflet.css'
 import L from 'leaflet'
 import type { Estacion } from '../types'
@@ -54,21 +55,7 @@ const Map: React.FC = () => {
     }).addTo(mapRef.current)
 
     // 3) Traigo las estaciones del backend
-    fetch('http://localhost:8081/api/estaciones', {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
-      .then(res => {
-        if (res.status === 401) {
-          // token inválido o expirado
-          localStorage.removeItem('jwtToken')
-          navigate('/', { replace: true })
-          throw new Error('No autorizado')
-        }
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        return res.json() as Promise<Estacion[]>
-      })
+    listEstaciones()
       .then(data => {
         data.forEach(est => {
             const marker = L.marker([est.latitud, est.longitud]).addTo(mapRef.current!)
@@ -83,7 +70,10 @@ const Map: React.FC = () => {
       })
       .catch(err => {
         console.error('Error al cargar estaciones:', err)
-        // aquí podrías mostrar un toast al usuario
+        if (err.response?.status === 401) {
+          localStorage.removeItem('jwtToken')
+          navigate('/', { replace: true })
+        }
       })
 
     // 4) Cleanup al desmontar

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { listNodos } from '../services/nodos';
+import { listEstaciones } from '../services/estaciones';
 import { useNavigate } from 'react-router-dom';
 import type { Estacion } from '../types'
 // interface Estacion {
@@ -9,7 +10,6 @@ import type { Estacion } from '../types'
 
 const Sidebar: React.FC = () => {
   const [estaciones, setEstaciones] = useState<Estacion[]>([]);
-  const token = localStorage.getItem('jwtToken');
   const navigate = useNavigate();
 
   const handleVerDatos = async (estacion: Estacion) => {
@@ -31,25 +31,16 @@ const Sidebar: React.FC = () => {
   }
 
   useEffect(() => {
-    fetch('http://localhost:8081/api/estaciones', {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
-      .then(res => {
-        if (res.status === 401) {
-          localStorage.removeItem('jwtToken');
-          window.location.href = '/';
-          throw new Error('No autorizado');
-        }
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json() as Promise<Estacion[]>;
-      })
-      .then(data => setEstaciones(data))
+    listEstaciones()
+      .then(setEstaciones)
       .catch(err => {
-        console.error('Error al cargar estaciones:', err);
-      });
-  }, [token]);
+        console.error('Error al cargar estaciones:', err)
+        if (err.response?.status === 401) {
+          localStorage.removeItem('jwtToken')
+          window.location.href = '/'
+        }
+      })
+  }, [])
 
   return (
     <div className="w-52 bg-gray-100 p-4 flex flex-col justify-between">

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,6 +1,7 @@
 // src/components/SignupForm.tsx
 import React, { useState } from 'react';
 import type { FormEvent } from 'react';
+import { register } from '../api';
 
 interface SignupData {
   email: string;
@@ -49,39 +50,7 @@ const SignupForm: React.FC = () => {
     setLoading(true);
 
     try {
-      const resp = await fetch('http://localhost:8081/auth/signup', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      });
-
-      if (!resp.ok) {
-        let errorMessage = 'Error en el registro';
-        window.scrollTo({ top: 0, behavior: "smooth" });
-        let errorBody: any = null;
-        let isJson = false;
-        try {
-          errorBody = await resp.clone().json();
-          isJson = true;
-        } catch {
-          errorBody = await resp.text();
-        }
-        if (isJson && errorBody) {
-          if (typeof errorBody.message === 'string') {
-        errorMessage = errorBody.message;
-          } else if (typeof errorBody === 'object') {
-        // Concatenar todos los mensajes de validación del backend
-        errorMessage = Object.values(errorBody)
-          .map((msg) => (Array.isArray(msg) ? msg.join(', ') : msg))
-          .join(' | ');
-          }
-        } else if (!isJson && typeof errorBody === 'string') {
-          errorMessage = errorBody || errorMessage;
-        }
-        throw new Error(errorMessage);
-      }
+      await register(formData);
       window.scrollTo({ top: 0, behavior: "smooth" });
       setSuccess('Usuario registrado correctamente');
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,10 +1,6 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081';
+import { api } from '../api'
 
 export async function getCurrentUser() {
-  const token = localStorage.getItem('jwtToken');
-  const res = await fetch(`${API_BASE}/auth/me`, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
-  if (!res.ok) throw new Error('No autorizado');
-  return res.json();
+  const { data } = await api.get('/auth/me')
+  return data
 }

--- a/src/services/estaciones.ts
+++ b/src/services/estaciones.ts
@@ -1,59 +1,27 @@
 // src/services/estaciones.ts
-import type { Estacion } from '../types';
-
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081';
-
-function authHeader(): Record<string, string> {
-  const token = localStorage.getItem('jwtToken');
-  if (token) {
-    return { Authorization: `Bearer ${token}` };
-  }
-  return {};
-}
+import { api } from '../api'
+import type { Estacion } from '../types'
 
 export async function listEstaciones(): Promise<Estacion[]> {
-  const res = await fetch(`${API_BASE}/api/estaciones`, {
-    headers: { ...authHeader() }
-  });
-  if (!res.ok) throw new Error(`Error ${res.status}`);
-  return res.json();
+  const { data } = await api.get('/api/estaciones')
+  return data
 }
 
 export async function createEstacion(
   data: Omit<Estacion, 'idEstacion'>,
 ): Promise<Estacion> {
-  const res = await fetch(`${API_BASE}/api/estaciones`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeader()
-    },
-    body: JSON.stringify(data)
-  });
-  if (!res.ok) throw new Error(`Error ${res.status}`);
-  return res.json();
+  const { data: res } = await api.post('/api/estaciones', data)
+  return res
 }
 
 export async function updateEstacion(
   id: number,
   data: Partial<Omit<Estacion, 'idEstacion'>>
 ): Promise<Estacion> {
-  const res = await fetch(`${API_BASE}/api/estaciones/${id}`, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeader()
-    },
-    body: JSON.stringify(data)
-  });
-  if (!res.ok) throw new Error(`Error ${res.status}`);
-  return res.json();
+  const { data: res } = await api.patch(`/api/estaciones/${id}`, data)
+  return res
 }
 
 export async function deleteEstacion(id: number): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/estaciones/${id}`, {
-    method: 'DELETE',
-    headers: { ...authHeader() }
-  });
-  if (!res.ok) throw new Error(`Error ${res.status}`);
+  await api.delete(`/api/estaciones/${id}`)
 }

--- a/src/services/mediciones.ts
+++ b/src/services/mediciones.ts
@@ -1,39 +1,17 @@
-// src/services/mediciones.ts
+import { api } from '../api'
 import type { Medicion, FilterParams } from '../types'
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
-function authHeader(): Record<string,string> {
-  const token = localStorage.getItem('jwtToken')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
-
-/** Obtiene la última medición de cada parámetro para un nodo */
 export async function getLastMedicionesByNodo(idNodo: number): Promise<Medicion[]> {
-  const res = await fetch(`${API_BASE}/api/mediciones/nodo/${idNodo}/last`, {
-    headers: authHeader()
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json()
+  const { data } = await api.get(`/api/mediciones/nodo/${idNodo}/last`)
+  return data
 }
 
-/** Filtra las mediciones con cuerpo JSON */
 export async function filterMediciones(params: FilterParams): Promise<Medicion[]> {
-  const res = await fetch(`${API_BASE}/api/mediciones/filter`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeader()
-    },
-    body: JSON.stringify(params)
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json()
+  const { data } = await api.post('/api/mediciones/filter', params)
+  return data
 }
-/**Filtra todo */
+
 export async function getAllMedicionesByNodo(idNodo: number): Promise<Medicion[]> {
-  const res = await fetch(`${API_BASE}/api/mediciones/nodo/${idNodo}`, {
-    headers: authHeader()
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json()
+  const { data } = await api.get(`/api/mediciones/nodo/${idNodo}`)
+  return data
 }

--- a/src/services/nodos.ts
+++ b/src/services/nodos.ts
@@ -1,39 +1,21 @@
+import { api } from '../api'
 import type { Nodo, NodoPayload } from '../types'
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
-function authHeader(): Record<string, string> {
-  const token = localStorage.getItem('jwtToken')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
-
 export async function listNodos(): Promise<Nodo[]> {
-  const res = await fetch(`${API_BASE}/api/nodos`, { headers: authHeader() })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json() as Promise<Nodo[]>
+  const { data } = await api.get('/api/nodos')
+  return data as Nodo[]
 }
 
 export async function createNodo(data: NodoPayload): Promise<Nodo> {
-  const res = await fetch(`${API_BASE}/api/nodos`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...authHeader() },
-    body: JSON.stringify(data)
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json() as Promise<Nodo>
+  const { data: res } = await api.post('/api/nodos', data)
+  return res as Nodo
 }
 
 export async function updateNodo(id: number, data: NodoPayload): Promise<Nodo> {
-  const res = await fetch(`${API_BASE}/api/nodos/${id}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', ...authHeader() },
-    body: JSON.stringify(data)
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json() as Promise<Nodo>
+  const { data: res } = await api.patch(`/api/nodos/${id}`, data)
+  return res as Nodo
 }
 
 export async function deleteNodo(id: number): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/nodos/${id}`, {
-    method: 'DELETE', headers: authHeader() })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
+  await api.delete(`/api/nodos/${id}`)
 }

--- a/src/services/parametros.ts
+++ b/src/services/parametros.ts
@@ -1,68 +1,26 @@
-// src/services/parametros.ts
+import { api } from '../api'
 import type { Parametro } from '../types'
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
-
-function authHeader(): Record<string, string> {
-  const token = localStorage.getItem('jwtToken')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
-
-/**
- * Obtiene todos los parámetros
- */
 export async function listParametros(): Promise<Parametro[]> {
-  const res = await fetch(`${API_BASE}/api/parametros`, {
-    headers: { ...authHeader() }
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json() as Promise<Parametro[]>
+  const { data } = await api.get('/api/parametros')
+  return data as Parametro[]
 }
 
-/**
- * Crea un nuevo parámetro
- */
 export async function createParametro(
   data: Omit<Parametro, 'id'>
 ): Promise<Parametro> {
-  const res = await fetch(`${API_BASE}/api/parametros`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeader()
-    },
-    body: JSON.stringify(data)
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json() as Promise<Parametro>
+  const { data: res } = await api.post('/api/parametros', data)
+  return res as Parametro
 }
 
-/**
- * Actualiza un parámetro existente
- */
 export async function updateParametro(
   id: number,
   data: Partial<Omit<Parametro, 'id'>>
 ): Promise<Parametro> {
-  const res = await fetch(`${API_BASE}/api/parametros/${id}`, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeader()
-    },
-    body: JSON.stringify(data)
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
-  return res.json() as Promise<Parametro>
+  const { data: res } = await api.patch(`/api/parametros/${id}`, data)
+  return res as Parametro
 }
 
-/**
- * Elimina un parámetro
- */
 export async function deleteParametro(id: number): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/parametros/${id}`, {
-    method: 'DELETE',
-    headers: { ...authHeader() }
-  })
-  if (!res.ok) throw new Error(`Error ${res.status}`)
+  await api.delete(`/api/parametros/${id}`)
 }

--- a/src/services/usuarios.ts
+++ b/src/services/usuarios.ts
@@ -1,64 +1,19 @@
-// src/services/personas.ts
+import { api } from '../api'
 import type { Usuario } from '../types'
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
-
-/**
- * Devuelve el header de autorización con el JWT si existe
- */
-function authHeader(): Record<string, string> {
-  const token = localStorage.getItem('jwtToken')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
-
-/**
- * Obtiene el listado de usuarios (personas) paginadas
- * y devuelve solo el array content.
- */
 export async function listUsuarios(): Promise<Usuario[]> {
-  const res = await fetch(`${API_BASE}/api/personas`, {
-    headers: { ...authHeader() }
-  })
-  if (!res.ok) {
-    throw new Error(`Error ${res.status}: ${res.statusText}`)
-  }
-  const data = await res.json() as {
-    content: Usuario[]
-    // otras props de paginación omitidas
-  }
-  return data.content
+  const { data } = await api.get('/api/personas')
+  return (data as { content: Usuario[] }).content
 }
 
-/**
- * Actualiza un usuario existente mediante PUT
- */
 export async function updateUsuario(
   id: number,
   data: Partial<Omit<Usuario, 'idPersona'>>
 ): Promise<Usuario> {
-  const res = await fetch(`${API_BASE}/api/personas/${id}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeader()
-    },
-    body: JSON.stringify(data)
-  })
-  if (!res.ok) {
-    throw new Error(`Error ${res.status}: ${res.statusText}`)
-  }
-  return res.json() as Promise<Usuario>
+  const { data: res } = await api.put(`/api/personas/${id}`, data)
+  return res as Usuario
 }
 
-/**
- * Elimina un usuario por su ID
- */
 export async function deleteUsuario(id: number): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/personas/${id}`, {
-    method: 'DELETE',
-    headers: { ...authHeader() }
-  })
-  if (!res.ok) {
-    throw new Error(`Error ${res.status}: ${res.statusText}`)
-  }
+  await api.delete(`/api/personas/${id}`)
 }


### PR DESCRIPTION
## Summary
- add `.env.example` with API URL
- ignore `.env` in gitignore
- create `src/api` with axios instance and auth helpers
- refactor service modules to use axios
- update components to use centralized API functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858b59a0a148330a6ba9abe09877f60